### PR TITLE
Re-export the Method type for easier use

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,4 @@
-use crate::RequestBuilder;
-use wasi::http::types::Method;
+use crate::{Method, RequestBuilder};
 
 #[derive(Default)]
 pub struct Client {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,3 +25,4 @@ mod response;
 pub use self::client::Client;
 pub use self::request::RequestBuilder;
 pub use self::response::Response;
+pub use wasi::http::types::Method;


### PR DESCRIPTION
```diff
- use wasi_http_client::Client;
- use wasi::http::types::Method;
+ use wasi_http_client::{Client, Method};
```